### PR TITLE
Added automatic refresh of cached session token 

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -4,7 +4,7 @@ module Bronto
   # login() API call remains active for 20 minutes.  In addition, the expiration time
   # is reset after each successful use.  We will trigger a refresh before 20 minutes 
   # to be on the safe side
-  SESSION_REUSE_SECONDS = 900
+  SESSION_REUSE_SECONDS = 120
 
   class Base
     attr_accessor :id, :api_key, :errors


### PR DESCRIPTION
For long running processes, such as rails child processes on a slow server, the cached Bronto session identifier created by login() could sometimes expire prior to being used and refreshed.  This patch adds a simple means of triggering a refresh if the token is likely to have expired.  
