### PR TITLE
Resolve issue with 502 error

### DIFF
--- a/lib/bronto/list.rb
+++ b/lib/bronto/list.rb
@@ -17,8 +17,8 @@ module Bronto
     def initialize(options = {})
       super(options)
       self.active_count ||= 0
-      if(!self.label.present?)
-        self.label =  self.name
+      if !self.label.present?
+        self.label = self.name
       end
     end
 

--- a/lib/bronto/list.rb
+++ b/lib/bronto/list.rb
@@ -17,6 +17,9 @@ module Bronto
     def initialize(options = {})
       super(options)
       self.active_count ||= 0
+      if(!self.label.present?)
+        self.label =  self.name
+      end
     end
 
     def add_to_list(*contacts)


### PR DESCRIPTION
A blank label can cause a "502 List with this name already exists" error if the label is empty. Bronto checks the name(internal name) and label (external name) of all existing lists when attempting to create a new list. If any list exists with a blank label, then trying to create a new list with a blank label will result in an error. This can be resolved by copying the name into the label at initialization, if no label is given.