### PR TITLE
Include type in Delivery hash

### DIFF
--- a/lib/bronto/delivery.rb
+++ b/lib/bronto/delivery.rb
@@ -33,7 +33,7 @@ module Bronto
       end
 
       hash = {
-        id: id, start: start_val, message_id: message_id, from_email: from_email, from_name: from_name,
+        id: id, start: start_val, message_id: message_id, type: type, from_email: from_email, from_name: from_name,
         reply_email: reply_email, recipients: recipients, fields: fields, authentication: authentication,
         reply_tracking: reply_tracking
       }


### PR DESCRIPTION
I ran into a problem with sending deliveries through Bronto of type "transactional." Occasionally, I was getting Error 224 from Bronto, "A transactional contact cannot be sent triggered messages." 

But I was setting "type: transactional" in my initializer to Bronto::Delivery.new, and I was seeing "type: transactional" when inspecting the Bronto::Delivery object before and after my request!

But then when looking at the actual SOAP request/response, I saw that even though I was setting "type: transactional" in the initializer, it wasn't making it to the SOAP. A little bit of digging, and it seems like it was simply omitted from Delivery's "to_hash" method. 

This seems to have fixed my problem. Please consider merging this into your code so others don't have the same problem!