### PR TITLE
Fix connection caching for multiple api keys

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -20,6 +20,10 @@ module Bronto
       @@api_key
     end
 
+    def self.connection_cache
+      @@connection_cache ||= {}
+    end
+
     # Simple helper method to convert class name to downcased pluralized version (e.g., Field -> fields).
     def self.plural_class_name
       self.to_s.split("::").last.downcase.pluralize
@@ -44,21 +48,26 @@ module Bronto
 
     # Sets up the Savon SOAP client object, including sessionHeaders and returns the client.
     def self.api(api_key, refresh = false)
-      return @api unless refresh || session_expired || @api.nil?
+      return connection_cache[api_key] unless refresh || session_expired(api_key) || connection_cache[api_key].nil?
 
       client = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', ssl_version: :TLSv1)
       resp = client.call(:login, message: { api_token: api_key })
 
-      @api = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', soap_header: {
-                                                                   "tns:sessionHeader" => { session_id: resp.body[:login_response][:return] }
-                                                                  },
-                                                                  read_timeout: 600) # Give Bronto up to 10 minutes to reply
+      connection_cache[api_key] = Savon.client(
+        wsdl: 'https://api.bronto.com/v4?wsdl',
+        soap_header: {
+          "tns:sessionHeader" => { session_id: resp.body[:login_response][:return] }
+        },
+        read_timeout: 600 # Give Bronto up to 10 minutes to reply
+      )
     end
 
     # returns true if a cached session identifier is missing or is too old
-    def self.session_expired
-      return true if (@last_used == nil)
-      return true if (Time.now.tv_sec - @last_used.tv_sec > SESSION_REUSE_SECONDS)
+    def self.session_expired(api_key)
+      return true if (connection_cache[api_key].nil?)
+      last_used = connection_cache[api_key][:last_used]
+      return true if (last_used == nil)
+      return true if (Time.now.tv_sec - last_used.tv_sec > SESSION_REUSE_SECONDS)
 
       false
     end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,0 +1,26 @@
+require_relative 'test_helper'
+
+class BaseTest < Test::Unit::TestCase
+  context "" do
+    teardown do
+      reset_all
+    end
+
+    should "reuse clients when the api key is the same" do
+      client1 = Bronto::Base.api('api-key-1')
+      client2 = Bronto::Base.api('api-key-1')
+
+      assert client1.is_a?(Savon::Client)
+      assert_equal client1, client2
+    end
+
+    should "not reuse clients when the api key is different" do
+      client1 = Bronto::Base.api('api-key-1')
+      client2 = Bronto::Base.api('api-key-2')
+
+      assert client1.is_a?(Savon::Client)
+      assert client2.is_a?(Savon::Client)
+      assert_not_equal client1, client2
+    end
+  end
+end


### PR DESCRIPTION
This fixes connection caching for apps that have multiple api keys.

Without this fix if you use multiple api keys in your app and you try
to change `Bronto::Base.api_key` you may get an api connection using
the wrong api key.