### PR TITLE
Specify TLSv1_2 to Savon client because Bronto is requiring TLS 1.2

### DIFF
--- a/lib/bronto/base.rb
+++ b/lib/bronto/base.rb
@@ -50,7 +50,7 @@ module Bronto
     def self.api(api_key, refresh = false)
       return connection_cache[api_key][:client] unless refresh || session_expired(api_key) || connection_cache[api_key].nil?
 
-      client = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', ssl_version: :TLSv1)
+      client = Savon.client(wsdl: 'https://api.bronto.com/v4?wsdl', ssl_version: :TLSv1_2)
       resp = client.call(:login, message: { api_token: api_key })
 
       connection_cache[api_key] = {


### PR DESCRIPTION
See http://blog.bronto.com/product/new-tls-protocols-bronto-users-need-know/ for more information, but basically Bronto is cutting off support for TLS < 1.2.  The hard cutoff date is May 24, but today they did a trial run where clients < TLS 1.2 were locked out for 4 hours.

The bronto gem specifies the TLS version when it uses the Savon client.
I understand this could break some Ruby setups that don't support TLS 1.2 yet. However, if there is no change made, then the gem will stop working entirely when Bronto rolls out their update.